### PR TITLE
Point "lock" depedency to the gxed version -  gx publish 0.1.1

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.1.0: QmTAQSKWDGV7MpNGZrcj9gzbBLk3vG77EcBkCQtPphCknP
+0.1.1: QmcdZD4zsP3PyNDbHkvjkvQx7dLLfbkSrRP8q5yPbDjqhj

--- a/package.json
+++ b/package.json
@@ -14,15 +14,15 @@
       "version": "1.2.7"
     },
     {
-      "hash": "QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52",
+      "hash": "QmRb5jh8z2E8hMGN2tkvs1yHynUanqnZ3UeKwgN1i9P1F8",
       "name": "go-log",
-      "version": "1.2.0"
+      "version": "1.4.0"
     },
     {
-      "author": "whyrusleeping",
-      "hash": "QmWi28zbQG6B1xfaaWx5cYoLn3kBFU6pQ6GWQNRV5P6dNe",
-      "name": "lock",
-      "version": "0.0.0"
+      "author": "hsanjuan",
+      "hash": "QmTevRdYUfixypqMWtSKDQ3hqr3QFCbfoBx6gbSxmfWoqT",
+      "name": "go4-lock",
+      "version": "0.0.1"
     }
   ],
   "gxVersion": "0.12.1",
@@ -30,6 +30,6 @@
   "license": "MIT",
   "name": "go-fs-lock",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.1.0"
+  "version": "0.1.1"
 }
 


### PR DESCRIPTION
The [gxed version](https://github.com/gxed/go4-lock) uses a newer version of sys (0.1.0) which is the one used by libp2p, thus removing one of the gx-duplicate-import warnings when working with both at the same time.

I will bubble this to ipfs since I'm at it.