### PR TITLE
Fix build on Plan 9

### DIFF
--- a/fslock.go
+++ b/fslock.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	util "github.com/ipfs/go-ipfs-util"
 	logging "github.com/ipfs/go-log"
@@ -30,10 +29,7 @@ func Lock(confdir, lockFileName string) (io.Closer, error) {
 	lk, err := lock.Lock(lockFilePath)
 	if err != nil {
 		switch {
-		case err == syscall.EAGAIN:
-			// EAGAIN == someone else has the lock
-			fallthrough
-		case strings.Contains(err.Error(), "resource temporarily unavailable"):
+		case lockedByOthers(err):
 			return lk, &os.PathError{
 				Op:   "lock",
 				Path: lockFilePath,

--- a/fslock_plan9.go
+++ b/fslock_plan9.go
@@ -1,0 +1,33 @@
+package fslock
+
+import "strings"
+
+// Opening an exclusive-use file returns an error.
+// The expected error strings are:
+//
+//  - "open/create -- file is locked" (cwfs, kfs)
+//  - "exclusive lock" (fossil)
+//  - "exclusive use file already open" (ramfs)
+//
+// See https://github.com/golang/go/blob/go1.15rc1/src/cmd/go/internal/lockedfile/lockedfile_plan9.go#L16
+var lockedErrStrings = [...]string{
+	"file is locked",
+	"exclusive lock",
+	"exclusive use file already open",
+}
+
+// isLockedPlan9 return whether an os.OpenFile error indicates that
+// a file with the ModeExclusive bit set is already open.
+func isLockedPlan9(s string) bool {
+	for _, frag := range lockedErrStrings {
+		if strings.Contains(s, frag) {
+			return true
+		}
+	}
+	return false
+}
+
+func lockedByOthers(err error) bool {
+	s := err.Error()
+	return strings.Contains(s, "Lock Create of") && isLockedPlan9(s)
+}

--- a/fslock_posix.go
+++ b/fslock_posix.go
@@ -1,0 +1,12 @@
+// +build !plan9
+
+package fslock
+
+import (
+	"strings"
+	"syscall"
+)
+
+func lockedByOthers(err error) bool {
+	return err == syscall.EAGAIN || strings.Contains(err.Error(), "resource temporarily unavailable")
+}


### PR DESCRIPTION
Plan 9 doesn't have syscall.EAGAIN. Copy some code from Go's internal
locakedfile package to check whether the file is locked by another
process.